### PR TITLE
feature: gps取得#3

### DIFF
--- a/src/app/gps-test/page.module.css
+++ b/src/app/gps-test/page.module.css
@@ -1,0 +1,102 @@
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: linear-gradient(180deg, #f6f8fb 0%, #edf2ff 100%);
+}
+
+.panel {
+  width: min(720px, 100%);
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.title {
+  color: #0f172a;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.description {
+  color: #334155;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  height: 40px;
+  padding: 0 14px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.primaryButton {
+  background: #0f172a;
+  color: #fff;
+}
+
+.secondaryButton {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #b91c1c;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 14px;
+}
+
+.result {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 16px;
+  color: #0f172a;
+  font-family: var(--font-geist-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  overflow-x: auto;
+}
+
+.placeholder {
+  color: #64748b;
+  font-size: 14px;
+}
+
+@media (max-width: 600px) {
+  .panel {
+    padding: 20px;
+  }
+
+  .title {
+    font-size: 24px;
+  }
+}

--- a/src/app/gps-test/page.tsx
+++ b/src/app/gps-test/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import {
+  type GeolocationErrorCode,
+  type GpsPosition,
+  getCurrentGpsPosition,
+} from "@/lib/geolocation";
+import styles from "./page.module.css";
+
+const formatNumber = (value: number | null, digit = 6) => {
+  if (value === null) {
+    return "-";
+  }
+
+  return value.toFixed(digit);
+};
+
+const errorLabel: Record<GeolocationErrorCode, string> = {
+  UNSUPPORTED: "UNSUPPORTED",
+  PERMISSION_DENIED: "PERMISSION_DENIED",
+  POSITION_UNAVAILABLE: "POSITION_UNAVAILABLE",
+  TIMEOUT: "TIMEOUT",
+  UNKNOWN: "UNKNOWN",
+};
+
+export default function GpsTestPage() {
+  const [position, setPosition] = useState<GpsPosition | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<GeolocationErrorCode | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleGetGps = async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    setErrorCode(null);
+
+    try {
+      const gps = await getCurrentGpsPosition();
+      setPosition(gps);
+    } catch (error) {
+      setPosition(null);
+
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "message" in error &&
+        "code" in error
+      ) {
+        setErrorMessage(String(error.message));
+        setErrorCode(error.code as GeolocationErrorCode);
+      } else {
+        setErrorMessage("位置情報の取得に失敗しました。");
+        setErrorCode("UNKNOWN");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const clearResult = () => {
+    setPosition(null);
+    setErrorMessage(null);
+    setErrorCode(null);
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.panel}>
+        <h1 className={styles.title}>GPS テストページ</h1>
+        <p className={styles.description}>
+          Geolocation API
+          から現在地を取得して表示します。ボタン押下時にブラウザの位置情報許可が求められます。
+        </p>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            onClick={handleGetGps}
+            disabled={isLoading}
+            className={styles.primaryButton}
+          >
+            {isLoading ? "取得中..." : "現在地を取得"}
+          </button>
+          <button
+            type="button"
+            onClick={clearResult}
+            className={styles.secondaryButton}
+          >
+            クリア
+          </button>
+          <Link href="/" className={styles.secondaryButton}>
+            トップへ戻る
+          </Link>
+        </div>
+
+        {errorMessage ? (
+          <div className={styles.error}>
+            {errorCode ? `[${errorLabel[errorCode]}] ` : ""}
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {position ? (
+          <pre className={styles.result}>
+            {`latitude: ${formatNumber(position.latitude)}
+longitude: ${formatNumber(position.longitude)}
+accuracy(m): ${formatNumber(position.accuracy, 2)}
+altitude(m): ${formatNumber(position.altitude, 2)}
+altitudeAccuracy(m): ${formatNumber(position.altitudeAccuracy, 2)}
+heading(deg): ${formatNumber(position.heading, 2)}
+speed(m/s): ${formatNumber(position.speed, 2)}
+timestamp: ${new Date(position.timestamp).toISOString()}`}
+          </pre>
+        ) : (
+          <p className={styles.placeholder}>
+            まだ位置情報は取得されていません。
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -63,6 +63,7 @@
 .ctas {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   width: 100%;
   max-width: 440px;
   gap: 16px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,9 @@ export default function Home() {
           </p>
         </div>
         <div className={styles.ctas}>
+          <a className={styles.secondary} href="/gps-test">
+            GPS Test Page
+          </a>
           <a
             className={styles.primary}
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -1,0 +1,103 @@
+export type GpsPosition = {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+  altitude: number | null;
+  altitudeAccuracy: number | null;
+  heading: number | null;
+  speed: number | null;
+  timestamp: number;
+};
+
+export type GeolocationErrorCode =
+  | "UNSUPPORTED"
+  | "PERMISSION_DENIED"
+  | "POSITION_UNAVAILABLE"
+  | "TIMEOUT"
+  | "UNKNOWN";
+
+export class GeolocationError extends Error {
+  constructor(
+    public readonly code: GeolocationErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GeolocationError";
+  }
+}
+
+const toGeolocationError = (
+  error: GeolocationPositionError,
+): GeolocationError => {
+  switch (error.code) {
+    case 1:
+      return new GeolocationError(
+        "PERMISSION_DENIED",
+        "位置情報の利用が許可されていません。",
+      );
+    case 2:
+      return new GeolocationError(
+        "POSITION_UNAVAILABLE",
+        "位置情報を取得できませんでした。",
+      );
+    case 3:
+      return new GeolocationError(
+        "TIMEOUT",
+        "位置情報の取得がタイムアウトしました。",
+      );
+    default:
+      return new GeolocationError(
+        "UNKNOWN",
+        "位置情報の取得中に不明なエラーが発生しました。",
+      );
+  }
+};
+
+export const getCurrentGpsPosition = (
+  options: PositionOptions = {},
+): Promise<GpsPosition> => {
+  if (typeof window === "undefined") {
+    return Promise.reject(
+      new GeolocationError(
+        "UNSUPPORTED",
+        "Geolocation APIはブラウザ環境でのみ利用できます。",
+      ),
+    );
+  }
+
+  if (!("geolocation" in navigator)) {
+    return Promise.reject(
+      new GeolocationError(
+        "UNSUPPORTED",
+        "このブラウザはGeolocation APIに対応していません。",
+      ),
+    );
+  }
+
+  const mergedOptions: PositionOptions = {
+    enableHighAccuracy: options.enableHighAccuracy ?? true,
+    timeout: options.timeout ?? 10000,
+    maximumAge: options.maximumAge ?? 0,
+  };
+
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        resolve({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+          accuracy: position.coords.accuracy,
+          altitude: position.coords.altitude,
+          altitudeAccuracy: position.coords.altitudeAccuracy,
+          heading: position.coords.heading,
+          speed: position.coords.speed,
+          timestamp: position.timestamp,
+        });
+      },
+      (error) => {
+        reject(toGeolocationError(error));
+      },
+      mergedOptions,
+    );
+  });
+};


### PR DESCRIPTION
このプルリクエストでは、アプリケーションに新しいGPSテストページを追加し、ユーザーがブラウザのGeolocation APIを使用して現在の位置情報を取得・表示できるようにします。これには、堅牢なエラー処理、ユーザーインターフェースコンポーネント、およびサポート用のユーティリティコードが含まれています。さらに、ホームページを更新して新しいテストページへのリンクを追加し、スタイルの軽微な改善も行っています。

**新しいGPSテスト機能:**

* 位置情報データを取得・表示するためのUI（`GpsTestPage`）を備えた新しいルート `/gps-test` を追加しました。これにはエラーメッセージやフォーマットされた結果も含まれます。（`src/app/gps-test/page.tsx`）
* レイアウト、ボタン、エラーメッセージ、結果のスタイルを設定するために、GPSテストページ専用のCSSモジュールを作成しました。(`src/app/gps-test/page.module.css`)

**位置情報ユーティリティ:**

* `geolocation.ts` に `getCurrentGpsPosition` を実装し、Geolocation API の使用を抽象化しました。これには、さまざまな失敗シナリオに対応したカスタムエラータイプやコードも含まれます。（`src/lib/geolocation.ts`）

**ホームページへの統合とスタイルの微調整:**

* ホームページにGPSテストページへのリンクを追加しました。（`src/app/page.tsx`）
* レスポンシブ性を向上させるため、ホームページのCTAにおけるボタンのラッピングを改善しました。（`src/app/page.module.css`）gps取得の関数を`/lib/