### PR TITLE
refactor: api base urlを環境変数で管理#7

### DIFF
--- a/src/actions/http.ts
+++ b/src/actions/http.ts
@@ -2,7 +2,8 @@ import "server-only";
 
 import type { ApiErrorResponse } from "./types";
 
-const DEFAULT_API_BASE_URL = "http://localhost:8080/api/v1";
+const DEFAULT_API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080/api/v1";
 
 type QueryValue = string | number | boolean | null | undefined;
 


### PR DESCRIPTION
直書きしていたapi base urlを`.env`の`NEXT_PUBLIC_API_BASE_URL`で管理するように変更しました

nao317/tsu_hack#7

close nao317/tsu_hack#7